### PR TITLE
Add nose2 instead of unittst to codecov

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -28,6 +28,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
           pip install coverage
+          pip install nose2
       - name: Generate Report
         run: |
           coverage run -m nose2 -v -B -s tests/integration

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -30,7 +30,7 @@ jobs:
           pip install coverage
       - name: Generate Report
         run: |
-          coverage run -m unittest discover
+          coverage run -m nose2 -v -B -s tests/integration
       - name: Upload Coverage to Codecov
         run: |
           curl -Os https://uploader.codecov.io/latest/linux/codecov


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Delete not needed sections -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- codecoverage github action fails, since it runs all unittests and integration tests, thus also tests that rely on hardware that is not connected to the test environment from github

## What is the new behavior?

- replace unittest discover  all tests with only the integration tests to discover

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
